### PR TITLE
Refactor sync/aio models to be able to initialize keys found in jv.Object parent classes

### DIFF
--- a/jsonversation/aio/models.py
+++ b/jsonversation/aio/models.py
@@ -31,7 +31,17 @@ class Object(StreamingObject[dict[str, Any]]):
         self._parsed_keys = []
         self._value = {}
 
-        for key, type_hint in type(self).__annotations__.items():
+        # initialize keys for potential parent classes
+        for cls in self.__class__.mro()[1:-1]:
+            if cls.__name__ == "Object" or cls.__name__ == "StreamingObject":
+                break
+
+            self._initialize_attributes(cls.__annotations__)
+
+        self._initialize_attributes(type(self).__annotations__)
+
+    def _initialize_attributes(self, attributes: dict[str, Any]) -> None:
+        for key, type_hint in attributes.items():
             self._keys.append(key)
 
             # Handle List[T]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jsonversation"
-version = "0.1.2"
+version = "0.1.3"
 description = "Fast and type-safe JSON stream parser"
 authors = [{name = "Vetted.ai Engineering", email = "engineering@vetted.ai"}]
 readme = "README.md"

--- a/tests/aio/models/test_object.py
+++ b/tests/aio/models/test_object.py
@@ -763,3 +763,15 @@ async def test_object_complete_complex_nested_streaming() -> None:
 
     assert footer_completed == ["Stream Footer"]  # Completed on final _complete()
     assert len(completed_values) == 1
+
+
+def test_object_creation_with_parent_classes() -> None:
+    class ParentObject(jv.Object):
+        name: jv.String
+
+    class ChildObject(ParentObject):
+        test_field: jv.String
+
+    o = ChildObject()
+
+    assert o.__getattribute__("name") is not None

--- a/tests/sync/models/test_object.py
+++ b/tests/sync/models/test_object.py
@@ -755,3 +755,15 @@ def test_object_complete_complex_nested_streaming() -> None:
 
     assert footer_completed == ["Stream Footer"]  # Completed on final _complete()
     assert len(completed_values) == 1
+
+
+def test_object_creation_with_parent_classes() -> None:
+    class ParentObject(jv.Object):
+        name: jv.String
+
+    class ChildObject(ParentObject):
+        test_field: jv.String
+
+    o = ChildObject()
+
+    assert o.__getattribute__("name") is not None

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "jsonversation"
-version = "0.1.0"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "jiter" },


### PR DESCRIPTION
Refactor Object model for both sync and aio to be able to initialize keys found in parent classes if those parent classes are also jsonversation.Object